### PR TITLE
Only give extra debugging output if -v given

### DIFF
--- a/NagAconda/Plugin.py
+++ b/NagAconda/Plugin.py
@@ -141,7 +141,8 @@ class Plugin:
         # Before we really do anything, make sure a warning or critical 
         # threshold were even set.
 
-        print 'range was ' + range_type
+        if self.options.verbose > 0:
+            print 'range was ' + range_type
 
         range_list = self.__warning
         if range_type == 'critical':
@@ -167,7 +168,8 @@ class Plugin:
         # The option parser should have already split these into proper
         # bottom, top, and match inversion, so long as the array element
         # is defined Perform our range test and set the exit status.
-        print range_list[threshold-1]
+        if self.options.verbose > 0:
+            print range_list[threshold-1]
         (bottom, top, invert) = range_list[threshold-1]
 
         if ((not invert and (val < bottom or val > top)) or
@@ -175,7 +177,8 @@ class Plugin:
             self.__exit_status = range_type
             self.__perf[name]['state'] = range_type
 
-        print "%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top)))
+        if self.options.verbose > 0:
+            print "%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top)))
 
     def add_option(self, flag, name, helptext, **kwargs):
         """
@@ -445,11 +448,14 @@ class Plugin:
         # variable is set so we don't have to loop through all of them later.
 
         if len(self.__warning) > 0:
-            print "checking warning"
+            
+            if self.options.verbose > 0:
+                print "checking warning"
             self.__check_range('warning', name)
 
         if len(self.__critical) > 0:
-            print "checking critical"
+            if self.options.verbose > 0:
+                print "checking critical"
             self.__check_range('critical', name)
 
         return self.__perf[name]['state']


### PR DESCRIPTION
Some extra debugging in the github version of this code outputs extra text.

eg.
checking warning
range was warning
(0, 1.0, False)
0.253954543692:0:1.0 =  False
checking critical
range was critical
(0, 2.0, False)
0.253954543692:0:2.0 =  False

This all comes out BEFORE the status line and makes it a little more difficult to track in Nagios. 

I've made a patch that checks if verbose (-v) was specified on the command line, and only display those extra lines when true.

Cheers,

Joel