### PR TITLE
Debug print statements should be --verbose only

### DIFF
--- a/NagAconda/Plugin.py
+++ b/NagAconda/Plugin.py
@@ -141,7 +141,8 @@ class Plugin:
         # Before we really do anything, make sure a warning or critical 
         # threshold were even set.
 
-        print 'range was ' + range_type
+        if self.options.verbose:
+            print 'range was ' + range_type
 
         range_list = self.__warning
         if range_type == 'critical':
@@ -167,7 +168,9 @@ class Plugin:
         # The option parser should have already split these into proper
         # bottom, top, and match inversion, so long as the array element
         # is defined Perform our range test and set the exit status.
-        print range_list[threshold-1]
+        if self.options.verbose:
+            print range_list[threshold-1]
+
         (bottom, top, invert) = range_list[threshold-1]
 
         if ((not invert and (val < bottom or val > top)) or
@@ -175,7 +178,8 @@ class Plugin:
             self.__exit_status = range_type
             self.__perf[name]['state'] = range_type
 
-        print "%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top)))
+        if self.options.verbose: 
+            print "%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top)))
 
     def add_option(self, flag, name, helptext, **kwargs):
         """
@@ -445,11 +449,13 @@ class Plugin:
         # variable is set so we don't have to loop through all of them later.
 
         if len(self.__warning) > 0:
-            print "checking warning"
+            if self.options.verbose:
+                print "checking warning"
             self.__check_range('warning', name)
 
         if len(self.__critical) > 0:
-            print "checking critical"
+            if self.options.verbose:
+                print "checking critical"
             self.__check_range('critical', name)
 
         return self.__perf[name]['state']


### PR DESCRIPTION
All the print statements in Plugin.py make this module unwieldy in Nagios.  It prints out the following debug information before the status is printed out:

checking warning
range was warning
(0, 20.0, False)
0.0:0:20.0 =  False
checking critical
range was critical
(0, 50.0, False)
0.0:0:50.0 =  False

Since this is all printed out first then all Nagios ever displays as a status is it's service summary is "checking warning".  These statements should all be printed only if self.options.verbose is set.