### PR TITLE
Multiple performance measurements & Extra debug message

### DIFF
--- a/NagAconda/Plugin.py
+++ b/NagAconda/Plugin.py
@@ -291,7 +291,8 @@ class Plugin:
                 perf_name, perf_dict['val'], perf_dict['scale'] or '',
                 perf_dict.get('raw_warning', ''),
                 perf_dict.get('raw_critical', ''),
-                perf_dict['min'] or '', perf_dict['max'] or '')
+                '' if perf_dict['min'] is None else perf_dict['min'],
+                '' if perf_dict['max'] is None else perf_dict['max'])
             )
 
         perf_string = ''

--- a/NagAconda/Plugin.py
+++ b/NagAconda/Plugin.py
@@ -141,7 +141,7 @@ class Plugin:
         # Before we really do anything, make sure a warning or critical 
         # threshold were even set.
 
-        print 'range was ' + range_type
+        self.__verbose_print('range was ' + range_type)
 
         range_list = self.__warning
         if range_type == 'critical':
@@ -167,7 +167,7 @@ class Plugin:
         # The option parser should have already split these into proper
         # bottom, top, and match inversion, so long as the array element
         # is defined Perform our range test and set the exit status.
-        print range_list[threshold-1]
+        self.__verbose_print(range_list[threshold-1])
         (bottom, top, invert, raw) = range_list[threshold-1]
 
         self.__perf[name]["raw_%s" % range_type] = raw
@@ -176,7 +176,7 @@ class Plugin:
            (invert and val >= bottom and val <= top)):
             self.__perf[name]['state'] = range_type
 
-        print "%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top)))
+        self.__verbose_print("%s:%s:%s =  %s" % (val, bottom, top, ((val < bottom) or (val > top))))
 
     def add_option(self, flag, name, helptext, **kwargs):
         """
@@ -449,11 +449,11 @@ class Plugin:
         # variable is set so we don't have to loop through all of them later.
 
         if len(self.__warning) > 0:
-            print "checking warning"
+            self.__verbose_print("checking warning")
             self.__check_range('warning', name)
 
         if len(self.__critical) > 0:
-            print "checking critical"
+            self.__verbose_print("checking critical")
             self.__check_range('critical', name)
 
         return self.__perf[name]['state']
@@ -550,6 +550,12 @@ class Plugin:
         """
         print 'Status Unknown: ' + message
         sys.exit(3)
+
+    def __verbose_print(self, *args):
+        if self.options.verbose is not None:
+            for arg in args:
+                print arg,
+            print
 
 def convert_range(option, opt_str, value, parser):
     """


### PR DESCRIPTION
1. When multiple performance measurements are set, like the Nagios plugin check_load:
  ```
  $ check_load -w 10,20,30 -c 20,30,40
  OK - load average: 0.09, 0.17, 0.16|load1=0.090;10.000;20.000;0; load5=0.170;20.000;30.000;0; load15=0.160;30.000;40.000;0;
  ```
  there are issues with status calculation and performance data format.

2. Extra debug message only be printed in verbose mode to avoid some issues (https://github.com/trifthen/NagAconda/issues/6, https://github.com/trifthen/NagAconda/issues/9)
